### PR TITLE
fix a bug parsing version numbers with a hyphen at the end

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -46,7 +46,8 @@ func nodeName() (string, error) {
 }
 
 func parseVersion(str string) (major, minor, patch int, err error) {
-	parts := strings.Split(str, ".")
+	versionNumber := strings.Split(str, "-")
+	parts := strings.Split(versionNumber[0], ".")
 	len := len(parts)
 
 	if major, err = strconv.Atoi(parts[0]); err != nil {


### PR DESCRIPTION
Using the latest Debian BBB image on beagleboard.org and noticed that the library failed to detect the proper version because running `uname -r` returns "3.8.13-bone47".  This is a quick fix to pre-split the version string in order to separate that part out.
