### PR TITLE
embd, rpi: determine pi revision, make rev2 pinmap default

### DIFF
--- a/host/rpi/rpi.go
+++ b/host/rpi/rpi.go
@@ -61,9 +61,9 @@ var ledMap = embd.LEDMap{
 
 func init() {
 	embd.Register(embd.HostRPi, func(rev int) *embd.Descriptor {
-		var pins = rev1Pins
-		if rev > 1 {
-			pins = rev2Pins
+		var pins = rev2Pins
+		if rev < 4 {
+			pins = rev1Pins
 		}
 
 		return &embd.Descriptor{


### PR DESCRIPTION
added a function to determine the revision of the pi the program is
running on from "Revision" field in /proc/cpuinfo, also made the rev2
gpio pinmap the default
