### PR TITLE
gpiodriver: added pinmap accessor for introspection usage

### DIFF
--- a/gpio.go
+++ b/gpio.go
@@ -125,6 +125,9 @@ type PWMPin interface {
 
 // GPIODriver implements a generic GPIO driver.
 type GPIODriver interface {
+	// Returns the pinmap for this GPIODriver
+	GetPinMap() (PinMap)
+
 	// Unregister unregisters the pin from the driver. Should be called when the pin is closed.
 	Unregister(string) error
 

--- a/gpiodriver.go
+++ b/gpiodriver.go
@@ -106,7 +106,9 @@ func (io *gpioDriver) PWMPin(key interface{}) (PWMPin, error) {
 
 	return p, nil
 }
-
+func (io *gpioDriver) GetPinMap() (PinMap) {
+	return io.pinMap
+}
 func (io *gpioDriver) Close() error {
 	for _, p := range io.initializedPins {
 		if err := p.Close(); err != nil {


### PR DESCRIPTION
This is pretty handy for finding out the pinmap on a device.