### PR TITLE
spi: added SPIBus.Write to allow writing without transfer delays.

### DIFF
--- a/host/generic/spibus.go
+++ b/host/generic/spibus.go
@@ -233,6 +233,14 @@ func (b *spiBus) ReceiveByte() (byte, error) {
 	return byte(d[0]), nil
 }
 
+func (b *spiBus) Write(data []uint8) (error) {
+        if err := b.init(); err != nil {
+                return err
+        }
+        _, err := b.file.Write(data)
+        return err
+}
+
 func (b *spiBus) Close() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/spi.go
+++ b/spi.go
@@ -33,6 +33,9 @@ type SPIBus interface {
 	// ReceiveByte receives a byte data.
 	ReceiveByte() (byte, error)
 
+	// WriteByte writes a buffer of data
+        Write([]uint8) (error)
+
 	// Close releases the resources associated with the bus.
 	Close() error
 }


### PR DESCRIPTION
Needed this to successfully drive LED strips via SPI.