### PR TITLE
added ReadBytes function to I2CBus interface and implementation

### DIFF
--- a/controller/hd44780/hd44780_test.go
+++ b/controller/hd44780/hd44780_test.go
@@ -131,7 +131,7 @@ type mockI2CBus struct {
 	closed bool
 }
 
-func (bus *mockI2CBus) ReadBytes(addr byte) ([]byte, error)      { return []byte{0x00}, nil }
+func (bus *mockI2CBus) ReadBytes(addr byte, num int) ([]byte, error)      { return []byte{0x00}, nil }
 func (bus *mockI2CBus) ReadByte(addr byte) (byte, error)                  { return 0x00, nil }
 func (bus *mockI2CBus) WriteBytes(addr byte, value []byte) error          { return nil }
 func (bus *mockI2CBus) ReadFromReg(addr, reg byte, value []byte) error    { return nil }

--- a/controller/hd44780/hd44780_test.go
+++ b/controller/hd44780/hd44780_test.go
@@ -131,6 +131,7 @@ type mockI2CBus struct {
 	closed bool
 }
 
+func (bus *mockI2CBus) ReadBytes(addr byte, num int) ([]byte, error) 	  { return []byte{0x00}, nil }
 func (bus *mockI2CBus) ReadByte(addr byte) (byte, error)                  { return 0x00, nil }
 func (bus *mockI2CBus) WriteBytes(addr byte, value []byte) error          { return nil }
 func (bus *mockI2CBus) ReadFromReg(addr, reg byte, value []byte) error    { return nil }

--- a/controller/hd44780/hd44780_test.go
+++ b/controller/hd44780/hd44780_test.go
@@ -131,7 +131,7 @@ type mockI2CBus struct {
 	closed bool
 }
 
-func (bus *mockI2CBus) ReadBytes(addr byte, num int) ([]byte, error) 	  { return []byte{0x00}, nil }
+func (bus *mockI2CBus) ReadBytes(addr byte, num int) ([]byte, error)      { return []byte{0x00}, nil }
 func (bus *mockI2CBus) ReadByte(addr byte) (byte, error)                  { return 0x00, nil }
 func (bus *mockI2CBus) WriteBytes(addr byte, value []byte) error          { return nil }
 func (bus *mockI2CBus) ReadFromReg(addr, reg byte, value []byte) error    { return nil }

--- a/controller/hd44780/hd44780_test.go
+++ b/controller/hd44780/hd44780_test.go
@@ -131,7 +131,7 @@ type mockI2CBus struct {
 	closed bool
 }
 
-func (bus *mockI2CBus) ReadBytes(addr byte, num int) ([]byte, error)      { return []byte{0x00}, nil }
+func (bus *mockI2CBus) ReadBytes(addr byte) ([]byte, error)      { return []byte{0x00}, nil }
 func (bus *mockI2CBus) ReadByte(addr byte) (byte, error)                  { return 0x00, nil }
 func (bus *mockI2CBus) WriteBytes(addr byte, value []byte) error          { return nil }
 func (bus *mockI2CBus) ReadFromReg(addr, reg byte, value []byte) error    { return nil }

--- a/host/generic/i2cbus.go
+++ b/host/generic/i2cbus.go
@@ -101,7 +101,7 @@ func (b *i2cBus) ReadByte(addr byte) (byte, error) {
 	return bytes[0], nil
 }
 
-func (b *i2cBus) ReadBytes(addr byte, num int) ([]byte, error) {
+func (b *i2cBus) ReadBytes(addr byte) ([]byte, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -113,10 +113,16 @@ func (b *i2cBus) ReadBytes(addr byte, num int) ([]byte, error) {
 		return []byte{0}, err
 	}
 
-	bytes := make([]byte, num)
+	info, err := b.file.Stat()
+	if err != nil {
+		return []byte{0}, err
+	}
+
+	size := int(info.Size())
+	bytes := make([]byte, size)
 	n, _ := b.file.Read(bytes)
 
-	if n != num {
+	if n != size {
 		return []byte{0}, fmt.Errorf("i2c: Unexpected number (%v) of bytes read", n)
 	}
 

--- a/host/generic/i2cbus.go
+++ b/host/generic/i2cbus.go
@@ -101,6 +101,28 @@ func (b *i2cBus) ReadByte(addr byte) (byte, error) {
 	return bytes[0], nil
 }
 
+func (b *i2cBus) ReadBytes(addr byte, num int) ([]byte, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if err := b.init(); err != nil {
+		return []byte{0}, err
+	}
+
+	if err := b.setAddress(addr); err != nil {
+		return []byte{0}, err
+	}
+
+	bytes := make([]byte, num)
+	n, _ := b.file.Read(bytes)
+
+	if n != num {
+		return []byte{0}, fmt.Errorf("i2c: Unexpected number (%v) of bytes read", n)
+	}
+
+	return bytes, nil
+}
+
 func (b *i2cBus) WriteByte(addr, value byte) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/host/generic/i2cbus.go
+++ b/host/generic/i2cbus.go
@@ -101,7 +101,7 @@ func (b *i2cBus) ReadByte(addr byte) (byte, error) {
 	return bytes[0], nil
 }
 
-func (b *i2cBus) ReadBytes(addr byte) ([]byte, error) {
+func (b *i2cBus) ReadBytes(addr byte, num int) ([]byte, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -113,16 +113,10 @@ func (b *i2cBus) ReadBytes(addr byte) ([]byte, error) {
 		return []byte{0}, err
 	}
 
-	info, err := b.file.Stat()
-	if err != nil {
-		return []byte{0}, err
-	}
-
-	size := int(info.Size())
-	bytes := make([]byte, size)
+	bytes := make([]byte, num)
 	n, _ := b.file.Read(bytes)
 
-	if n != size {
+	if n != num {
 		return []byte{0}, fmt.Errorf("i2c: Unexpected number (%v) of bytes read", n)
 	}
 

--- a/i2c.go
+++ b/i2c.go
@@ -5,6 +5,8 @@ package embd
 // I2CBus interface is used to interact with the I2C bus.
 type I2CBus interface {
 	// ReadByte reads a byte from the given address.
+	ReadBytes(addr byte, num int) (value []byte, err error)
+	// ReadByte reads a byte from the given address.
 	ReadByte(addr byte) (value byte, err error)
 	// WriteByte writes a byte to the given address.
 	WriteByte(addr, value byte) error

--- a/i2c.go
+++ b/i2c.go
@@ -4,6 +4,8 @@ package embd
 
 // I2CBus interface is used to interact with the I2C bus.
 type I2CBus interface {
+	// ReadBytes reads a slice of bytes from the given address.
+	ReadBytes(addr byte) (value []byte, err error)
 	// ReadByte reads a byte from the given address.
 	ReadByte(addr byte) (value byte, err error)
 	// ReadBytes reads a slice of bytes from the given address.

--- a/i2c.go
+++ b/i2c.go
@@ -6,7 +6,7 @@ package embd
 type I2CBus interface {
 	// ReadByte reads a byte from the given address.
 	ReadBytes(addr byte, num int) (value []byte, err error)
-	// ReadByte reads a byte from the given address.
+	// ReadByte reads a slice of bytes from the given address.
 	ReadByte(addr byte) (value byte, err error)
 	// WriteByte writes a byte to the given address.
 	WriteByte(addr, value byte) error

--- a/i2c.go
+++ b/i2c.go
@@ -5,9 +5,9 @@ package embd
 // I2CBus interface is used to interact with the I2C bus.
 type I2CBus interface {
 	// ReadByte reads a byte from the given address.
-	ReadBytes(addr byte, num int) (value []byte, err error)
-	// ReadByte reads a slice of bytes from the given address.
 	ReadByte(addr byte) (value byte, err error)
+	// ReadBytes reads a slice of bytes from the given address.
+	ReadBytes(addr byte, num int) (value []byte, err error)
 	// WriteByte writes a byte to the given address.
 	WriteByte(addr, value byte) error
 	// WriteBytes writes a slice bytes to the given address.

--- a/i2c.go
+++ b/i2c.go
@@ -4,8 +4,6 @@ package embd
 
 // I2CBus interface is used to interact with the I2C bus.
 type I2CBus interface {
-	// ReadBytes reads a slice of bytes from the given address.
-	ReadBytes(addr byte) (value []byte, err error)
 	// ReadByte reads a byte from the given address.
 	ReadByte(addr byte) (value byte, err error)
 	// ReadBytes reads a slice of bytes from the given address.


### PR DESCRIPTION
I added a ReadBytes function to the I2CBus interface since I needed it for a project I'm working on. It's a very simple adaptation of the ReadByte function- I did the simplest thing that worked. All tests pass a simple `go test -v`. Did my best to follow the contribution guidelines- let me know if I missed anything.