### PR TITLE
add csChange, pad fields to spiIOCTransfer struct

### DIFF
--- a/host/generic/spibus.go
+++ b/host/generic/spibus.go
@@ -36,6 +36,9 @@ type spiIOCTransfer struct {
 	speedHz     uint32
 	delayus     uint16
 	bitsPerWord uint8
+
+	csChange uint8
+	pad      uint32
 }
 
 type spiBus struct {


### PR DESCRIPTION
Per the discussion in #38, these two fields are part of the equivalent struct in the kernel SPI driver. Adding the fields allows the SPI driver to work on a Raspberry Pi Model 2 B.

h/t @hbhasker

Fixes #38. Fixes #24.