### PR TITLE
Unexport digital pins on Close().

### DIFF
--- a/host/generic/digitalpin.go
+++ b/host/generic/digitalpin.go
@@ -236,6 +236,10 @@ func (p *digitalPin) Close() error {
 		return err
 	}
 
+	if err := p.unexport(); err != nil {
+		return err
+	}
+
 	if !p.initialized {
 		return nil
 	}
@@ -247,9 +251,6 @@ func (p *digitalPin) Close() error {
 		return err
 	}
 	if err := p.activeLow.Close(); err != nil {
-		return err
-	}
-	if err := p.unexport(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Exported digital pins can be uninitialized.

#### How to reproduce the problem

```go
package main

import (
        "fmt"

        "github.com/kidoman/embd"
        _ "github.com/wujiang/embd/host/rpi"
)

func main() {
        embd.InitGPIO()
        defer embd.CloseGPIO()
        fmt.Println(embd.SetDirection(12, embd.Out))
}
```

```sh
/tmp $ go build
/tmp $ ./tmp
open /sys/class/gpio/gpio12/direction: permission denied
/tmp $ ./tmp
write /sys/class/gpio/export: device or resource busy
/tmp $ ./tmp
write /sys/class/gpio/export: device or resource busy
/tmp $ ls /sys/class/gpio/
export  gpio12  gpiochip0  unexport
```

After the change:

```sh
/tmp $ ./tmp
open /sys/class/gpio/gpio12/direction: permission denied
/tmp $ ./tmp
open /sys/class/gpio/gpio12/direction: permission denied
/tmp $ ./tmp
open /sys/class/gpio/gpio12/direction: permission denied
```