### PR TITLE
Adding Support for MCP3208 (12 bit version of MCP3008)

### DIFF
--- a/convertors/mcp3008/mcp3008.go
+++ b/convertors/mcp3008/mcp3008.go
@@ -38,9 +38,17 @@ const (
 // AnalogValueAt returns the analog value at the given channel of the convertor.
 func (m *MCP3008) AnalogValueAt(chanNum int) (int, error) {
 	var data [3]uint8
-	data[0] = startBit
-	data[1] = uint8(m.Mode)<<7 | uint8(chanNum)<<4
-	data[2] = 0
+	switch m.Bits {
+	case Bits10:
+		data[0] = startBit
+		data[1] = uint8(m.Mode)<<7 | uint8(chanNum)<<4
+		data[2] = 0
+	case Bits12:
+		//[0x06| (channel >> 2), channel << 6, 0]
+		data[0] = 0x06 | (uint8(chanNum) >> 2)
+		data[1] = uint8(chanNum) << 6
+		data[2] = 0
+	}
 
 	glog.V(2).Infof("mcp3008: sendingdata buffer %v", data)
 	if err := m.Bus.TransferAndReceiveData(data[:]); err != nil {

--- a/convertors/mcp3008/mcp3008.go
+++ b/convertors/mcp3008/mcp3008.go
@@ -44,8 +44,7 @@ func (m *MCP3008) AnalogValueAt(chanNum int) (int, error) {
 		data[1] = uint8(m.Mode)<<7 | uint8(chanNum)<<4
 		data[2] = 0
 	case Bits12:
-		//[0x06| (channel >> 2), channel << 6, 0]
-		data[0] = 0x06 | (uint8(chanNum) >> 2)
+		data[0] = (uint8(startBit) << 2) + (uint8(m.Mode) << 1) + (uint8(chanNum) >> 2)
 		data[1] = uint8(chanNum) << 6
 		data[2] = 0
 	}

--- a/samples/mcp3208.go
+++ b/samples/mcp3208.go
@@ -41,7 +41,7 @@ func main() {
 		time.Sleep(1 * time.Second)
 		val, err := adc.AnalogValueAt(0)
 		if err != nil {
-			panic(err)
+			fmt.Println("Error: ", err)
 		}
 		fmt.Printf("analog value is: %v\n", val)
 	}

--- a/samples/mcp3208.go
+++ b/samples/mcp3208.go
@@ -1,0 +1,48 @@
+// +build ignore
+
+// this sample uses the mcp3008 package to interface with a similar MCP3208, which is a 12 bit variant. Works without code change on bbb and rpi
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/kidoman/embd"
+	// "github.com/kidoman/embd/convertors/mcp3008"
+	_ "github.com/kidoman/embd/host/all"
+	"github.com/npotts/embd/convertors/mcp3008"
+)
+
+const (
+	channel = 0
+	speed   = 1000000
+	bpw     = 8
+	delay   = 0
+)
+
+func main() {
+	flag.Parse()
+	fmt.Println("this is a sample code for mcp3008 10bit 8 channel ADC")
+
+	if err := embd.InitSPI(); err != nil {
+		panic(err)
+	}
+	defer embd.CloseSPI()
+
+	spiBus := embd.NewSPIBus(embd.SPIMode0, channel, speed, bpw, delay)
+	defer spiBus.Close()
+
+	adc := &mcp3008.MCP3008{Mode: mcp3008.SingleMode, Bus: spiBus, Bits: mcp3008.Bits12}
+
+	// adc := mcp3008.New(mcp3008.SingleMode, spiBus)
+
+	for i := 0; i < 20; i++ {
+		time.Sleep(1 * time.Second)
+		val, err := adc.AnalogValueAt(0)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("analog value is: %v\n", val)
+	}
+}


### PR DESCRIPTION
I have hacked in support for a MCP3204/8 (12 bit version of MCP3004/8), and I am wondering if i should add it into the MCP3008 struct, or make a copy of the 3008 - Per the datasheets precious little else is different.  

On RPi2+, this also needs the patch from #24 
