### PR TITLE
Give rpi some time to link digital pin property

### DIFF
--- a/host/generic/digitalpin.go
+++ b/host/generic/digitalpin.go
@@ -47,6 +47,8 @@ func (p *digitalPin) init() error {
 	if err = p.export(); err != nil {
 		return err
 	}
+	// give rpi some time to link digital pin property
+	time.Sleep(100 * time.Millisecond)
 	if p.dir, err = p.directionFile(); err != nil {
 		return err
 	}


### PR DESCRIPTION
It looks like Raspberry pi needs some time to get a digital pin link properly after it is being exported.

Sample code to run:

```go
package main

import (
        "fmt"

        "github.com/kidoman/embd"
         _ "github.com/kidoman/embd/host/rpi"
)

func main() {
        defer embd.CloseGPIO()
        fmt.Println(embd.SetDirection(10, embd.Out))
}

```

- before the change, the output is `open /sys/class/gpio/gpio10/direction: permission denied`

- after the change, the output is `<nil>`

Close #52