### PR TITLE
Fixed SPIController issue with missing fields

### DIFF
--- a/host/generic/spibus.go
+++ b/host/generic/spibus.go
@@ -36,6 +36,8 @@ type spiIOCTransfer struct {
 	speedHz     uint32
 	delayus     uint16
 	bitsPerWord uint8
+	csChange    uint8
+	pad         uint32
 }
 
 type spiBus struct {


### PR DESCRIPTION
Added missing fields to use the SPI interface with Raspberry Pi. Tested with Pi2 and Pi B+.