### PR TITLE
digitalPin: do not export if the /sys/class/gpio/... file already exists

### DIFF
--- a/host/generic/digitalpin.go
+++ b/host/generic/digitalpin.go
@@ -62,7 +62,21 @@ func (p *digitalPin) init() error {
 	return nil
 }
 
+func (p *digitalPin) isExported() bool {
+	if _, err := os.Stat(p.basePath()); err == nil {
+		return true
+	} else if os.IsNotExist(err) {
+		return false
+	} else {
+		// unknown
+		return false
+	}
+}
+
 func (p *digitalPin) export() error {
+	if p.isExported() {
+		return nil
+	}
 	exporter, err := os.OpenFile("/sys/class/gpio/export", os.O_WRONLY, os.ModeExclusive)
 	if err != nil {
 		return err

--- a/host/generic/spibus.go
+++ b/host/generic/spibus.go
@@ -36,6 +36,8 @@ type spiIOCTransfer struct {
 	speedHz     uint32
 	delayus     uint16
 	bitsPerWord uint8
+	csChange    uint8
+	pad         uint32
 }
 
 type spiBus struct {


### PR DESCRIPTION
Change digitalPin to allow the use of an already exported gpio pin, avoiding the `write /sys/class/gpio/export: device or resource busy` errors that currently result. This kind of situation is easy to end up in if you e.g. kill the process and restart it, without giving it a chance to unexport its pins.

This should suffice to handle the issues mentioned in #30 and #44.

This also helps to deal with the `open /sys/class/gpio/gpio21/direction: permission denied` races in #52, by allowing us to use a helper script to pre-export the gpio pins and wait for udev to settle.