### PR TITLE
fix fatal error: concurrent map read and map write

### DIFF
--- a/host/generic/interrupt.go
+++ b/host/generic/interrupt.go
@@ -61,11 +61,13 @@ func initEpollListener() *epollListener {
 			if err != nil {
 				panic(fmt.Sprintf("EpollWait error: %v", err))
 			}
+			listener.mu.Lock()
 			for i := 0; i < n; i++ {
 				if irq, ok := listener.interruptablePins[int(epollEvents[i].Fd)]; ok {
 					irq.Signal()
 				}
 			}
+			listener.mu.Unlock()
 		}
 	}()
 	return listener


### PR DESCRIPTION
fatal error: concurrent map read and map write

goroutine 18 [running]:
runtime.throw(0x233cf7, 0x21)
        D:/Go/src/runtime/panic.go:566 +0x78 fp=0x10618364 sp=0x10618358
runtime.mapaccess2_fast32(0x203100, 0x106c9880, 0xa, 0x40, 0xffffffff)
        D:/Go/src/runtime/hashmap_fast.go:66 +0x5c fp=0x10618374 sp=0x10618364
github.com/kidoman/embd/host/generic.initEpollListener.func1(0x106e59b0)
        G:/GOPATH/src/github.com/kidoman/embd/host/generic/interrupt.go:65 +0x1b0 fp=0x106187d4 sp=0x10618374
runtime.goexit()
        D:/Go/src/runtime/asm_arm.s:998 +0x4 fp=0x106187d4 sp=0x106187d4
created by github.com/kidoman/embd/host/generic.initEpollListener
        G:/GOPATH/src/github.com/kidoman/embd/host/generic/interrupt.go:70 +0x194
