### PR TITLE
Ignore EINTR signal

### DIFF
--- a/host/generic/interrupt.go
+++ b/host/generic/interrupt.go
@@ -58,6 +58,9 @@ func initEpollListener() *epollListener {
 
 		for {
 			n, err := syscall.EpollWait(listener.fd, epollEvents[:], -1)
+			if err == syscall.EINTR {
+				continue
+			}
 			if err != nil {
 				panic(fmt.Sprintf("EpollWait error: %v", err))
 			}


### PR DESCRIPTION
Today I hit a scenario where embd will panic if I `strace -fp <PID>` the OS process. This lead to interrupt handling, this is a known issue, and the workaround is pretty much taken from here: https://github.com/davecheney/gpio/issues/12 