### PR TITLE
Update i2c.go

### DIFF
--- a/i2c.go
+++ b/i2c.go
@@ -66,6 +66,7 @@ func InitI2C() error {
 
 // CloseI2C releases resources associated with the I2C driver.
 func CloseI2C() error {
+	i2cDriverInitialized = false
 	return i2cDriverInstance.Close()
 }
 


### PR DESCRIPTION
We have to reset i2cDriverInitialized, to initialize the driver correct, after closing it.

Following code is not working in current repo.

```
for {
    if err := embd.InitI2C(); err != nil {
        panic(err)
    }

    bus := embd.NewI2CBus(1)

    conn, err := hd44780.NewI2C(
		bus,
		0x3f,
		hd44780.PCF8574PinMap,
		hd44780.RowAddress16Col,
		hd44780.TwoLine,
		hd44780.BlinkOff,
    )
    if err != nil {
 	panic(err)
    }

    conn.Clear()
    conn.BacklightOn()
	
    message := "HDTest"
    bytes := []byte(message)
    for _, b := range bytes {
        conn.WriteChar(b)
    }
	    
    conn.Close()
    embd.CloseI2C()
		
    time.Sleep(2*time.Second)
}
```