### PR TITLE
Correctly detect Raspberry Pi 3 on Kernel 4.9

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -124,7 +124,7 @@ func DetectHost() (host Host, rev int, err error) {
 	switch {
 	case strings.Contains(model, "ARMv7") && (strings.Contains(hardware, "AM33XX") || strings.Contains(hardware, "AM335X")):
 		return HostBBB, rev, nil
-	case strings.Contains(hardware, "BCM2708") || strings.Contains(hardware, "BCM2709"):
+	case strings.Contains(hardware, "BCM2708") || strings.Contains(hardware, "BCM2709") || strings.Contains(hardware, "BCM2835"):
 		return HostRPi, rev, nil
 	case hardware == "Allwinner sun4i/sun5i Families":
 		if major < 4 || (major == 4 && minor < 4) {


### PR DESCRIPTION
Kernel 4.9 now correctly identifies the hardware for the Raspberry Pi 3 as "BCM2835", /proc/cpuinfo contains:

    processor      : 0
    model name     : ARMv7 Processor rev 4 (v7l)
    BogoMIPS       : 38.40
    Features       : half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm crc32
    CPU implementer        : 0x41
    CPU architecture: 7
    CPU variant    : 0x0
    CPU part       : 0xd03
    CPU revision   : 4
    [...]
    Hardware       : BCM2835
    Revision       : a02082
