### PR TITLE
Pi4 support

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -124,7 +124,7 @@ func DetectHost() (host Host, rev int, err error) {
 	switch {
 	case strings.Contains(model, "ARMv7") && (strings.Contains(hardware, "AM33XX") || strings.Contains(hardware, "AM335X")):
 		return HostBBB, rev, nil
-	case strings.Contains(hardware, "BCM2708") || strings.Contains(hardware, "BCM2709") || strings.Contains(hardware, "BCM2835") || strings.Contains("BCM2711"):
+	case strings.Contains(hardware, "BCM2708") || strings.Contains(hardware, "BCM2709") || strings.Contains(hardware, "BCM2835") || strings.Contains(hardware, "BCM2711"):
 		return HostRPi, rev, nil
 	case hardware == "Allwinner sun4i/sun5i Families":
 		if major < 4 || (major == 4 && minor < 4) {

--- a/detect.go
+++ b/detect.go
@@ -124,7 +124,7 @@ func DetectHost() (host Host, rev int, err error) {
 	switch {
 	case strings.Contains(model, "ARMv7") && (strings.Contains(hardware, "AM33XX") || strings.Contains(hardware, "AM335X")):
 		return HostBBB, rev, nil
-	case strings.Contains(hardware, "BCM2708") || strings.Contains(hardware, "BCM2709") || strings.Contains(hardware, "BCM2835"):
+	case strings.Contains(hardware, "BCM2708") || strings.Contains(hardware, "BCM2709") || strings.Contains(hardware, "BCM2835") || strings.Contains("BCM2711"):
 		return HostRPi, rev, nil
 	case hardware == "Allwinner sun4i/sun5i Families":
 		if major < 4 || (major == 4 && minor < 4) {


### PR DESCRIPTION
@kidoman embd is broken in pi4 due to cpu hardware code being different. We use embd to power reef-pi and would greatly appreciate if we could make it run without maintaining custom patches.
Thank you, and let me know if i can lend a hand with the maintenance chores 